### PR TITLE
changed the images to be cover sized and updated readme build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Build & development
 
-Run `grunt build` for building and `grunt serve` for preview.
+Run `npm install && bower install && grunt build` for building and `grunt serve` for preview.
 
 ## Testing
 

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -22,35 +22,43 @@ body:after {
 
 /* Background styles */
 .default {
-  background: url("../images/default.jpg") no-repeat;
+  background: url("../images/default.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .day-clear {
-  background: url("../images/day-clear.jpg") no-repeat;
+  background: url("../images/day-clear.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .night-clear {
-  background: url("../images/night-clear.jpg") no-repeat;
+  background: url("../images/night-clear.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .night-cloudy {
-  background: url("../images/night-cloudy.jpg") no-repeat;
+  background: url("../images/night-cloudy.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .cloudy {
-  background: url("../images/cloudy.jpg") no-repeat;
+  background: url("../images/cloudy.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .rainy {
-  background: url("../images/rainy.jpg") no-repeat;
+  background: url("../images/rainy.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .thunderstorm {
-  background: url("../images/thunderstorm.jpg") no-repeat;
+  background: url("../images/thunderstorm.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 .foggy {
-  background: url("../images/foggy.jpg") no-repeat;
+  background: url("../images/foggy.jpg") no-repeat center center fixed;
+  background-size: cover;
 }
 
 /* centered columns styles */


### PR DESCRIPTION
I stumbled across this when looking for something to build into a bathroom "smart mirror" with large screens the background images only extend so far and then there is just ugly white space. 

But this cuts off the top and bottom of the images when viewed on smaller screens. I can also update it to just use height 100% and let the sides overflow. 
